### PR TITLE
Fix parameter typo in screenSizer

### DIFF
--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -653,7 +653,7 @@ interface ScreenSizer {
     gameOffset: Offset;
     gameElements: HTMLCanvasElement[];
     center: Offset;
-    setGameElement(elemenet: HTMLElement): void;
+    setGameElement(element: HTMLElement): void;
     setGameElements(listOfIds: string[]): void;
     orientationChangeCallback(newScreenSize: ScreenSize): void;
     handleOrientation(): void;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -653,7 +653,7 @@ interface ScreenSizer {
     gameOffset: Offset;
     gameElements: HTMLCanvasElement[];
     center: Offset;
-    setGameElement(elemenet: HTMLElement): void;
+    setGameElement(element: HTMLElement): void;
     setGameElements(listOfIds: string[]): void;
     orientationChangeCallback(newScreenSize: ScreenSize): void;
     handleOrientation(): void;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6802,8 +6802,8 @@ var screenSizer = {
   gameOffset: { x: 0, y: 0 },
   gameElements: [],
   center: { x: 0, y: 0 },
-  setGameElement(elemenet) {
-    this.setGameElements([elemenet.id]);
+  setGameElement(element) {
+    this.setGameElements([element.id]);
   },
   setGameElements(listOfIds) {
     const domList = [];

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -6758,8 +6758,8 @@ var screenSizer = {
   gameOffset: { x: 0, y: 0 },
   gameElements: [],
   center: { x: 0, y: 0 },
-  setGameElement(elemenet) {
-    this.setGameElements([elemenet.id]);
+  setGameElement(element) {
+    this.setGameElements([element.id]);
   },
   setGameElements(listOfIds) {
     const domList = [];

--- a/src/screenResizer.ts
+++ b/src/screenResizer.ts
@@ -13,7 +13,7 @@ interface ScreenSize {
     gameOffset: Offset;
     gameElements: HTMLCanvasElement[];
     center: Offset;
-    setGameElement(elemenet: HTMLElement):void;
+    setGameElement(element: HTMLElement):void;
     setGameElements(listOfIds: string[]): void;
     orientationChangeCallback(newScreenSize: ScreenSize): void;
     handleOrientation(): void;
@@ -40,8 +40,8 @@ interface ScreenSize {
     gameElements: [],
     center: { x: 0, y: 0 },
   
-    setGameElement(elemenet: HTMLElement){
-        this.setGameElements([elemenet.id]);
+    setGameElement(element: HTMLElement){
+        this.setGameElements([element.id]);
     },
     setGameElements(listOfIds: string[]) {
       const domList: HTMLCanvasElement[] = [];


### PR DESCRIPTION
## Summary
- rename `elemenet` parameter to `element` in `screenResizer`
- update usage of the renamed parameter
- update built files and typings to reflect the change

## Testing
- `npm run build` *(fails: tsup not found)*