### PR TITLE
chore: add preliminary eslint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "root": true
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "npm-bump-version-major": "npm version major",
     "link": "npm link",
     "test": "npx tsc -p tsconfig.tests.json && node --test dist-tests/tests/*.js",
+    "lint": "eslint . --ext .ts --config .eslintrc.json",
     "prepare": "npm run build"
   },
   "keywords": [
@@ -28,6 +29,10 @@
     "@types/node": "^24.0.14",
     "peerjs": "^1.5.4",
     "tsup": "^7.2.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^15.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add eslint and TypeScript-related plugins to `devDependencies`
- scaffold Next.js-style ESLint configuration

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "next" to extend from; dependencies not installed due to 403 when fetching from npm registry)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b39cc458d883308f5f0522a868d107