### PR TITLE
feat: allow configuring request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Laser-Mace is my personal Swiss army knife of tools—a collection of utilities 
 
 ### Miscellaneous Utilities
 
-- **sendRequest(url, payload)**: Make HTTP requests with JSON payloads.
+- **sendRequest(url, payload, timeoutMs?)**: Make HTTP requests with JSON payloads. Timeout defaults to `5000` ms.
 - **getKeyNameByValue(obj, value)**: Retrieve an object's key by its value.
 - **attachOnClick(id, fn, params, callback)**: Bind functions to elements by their `id`.
 

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -340,16 +340,21 @@ declare function removeByIdInPlace(array: any[], idToRemove: any): void;
  * @template T - The expected response type.
  * @param {string} url - The endpoint to which the request is sent.
  * @param {Record<string, unknown>} payload - The data to be sent in the request body.
+ * @param {number} [timeoutMs=5000] - Duration before the request is aborted, in milliseconds.
  * @returns {Promise<T | undefined>} A promise resolving to the response of the request, or `undefined` if an error occurs.
  *
  * @example
  * // Example usage:
- * const response = await sendRequest<MyResponseType>("https://api.example.com/data", { key: "value" });
+ * const response = await sendRequest<MyResponseType>(
+ *     "https://api.example.com/data",
+ *     { key: "value" },
+ *     10000,
+ * );
  * if (response) {
  *     console.log("Success:", response);
  * }
  */
-declare function sendRequest<T>(url: string, payload: Record<string, unknown> | undefined): Promise<T | undefined>;
+declare function sendRequest<T>(url: string, payload: Record<string, unknown> | undefined, timeoutMs?: number): Promise<T | undefined>;
 
 type HandlerFunction = (...args: any[]) => void;
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -340,16 +340,21 @@ declare function removeByIdInPlace(array: any[], idToRemove: any): void;
  * @template T - The expected response type.
  * @param {string} url - The endpoint to which the request is sent.
  * @param {Record<string, unknown>} payload - The data to be sent in the request body.
+ * @param {number} [timeoutMs=5000] - Duration before the request is aborted, in milliseconds.
  * @returns {Promise<T | undefined>} A promise resolving to the response of the request, or `undefined` if an error occurs.
  *
  * @example
  * // Example usage:
- * const response = await sendRequest<MyResponseType>("https://api.example.com/data", { key: "value" });
+ * const response = await sendRequest<MyResponseType>(
+ *     "https://api.example.com/data",
+ *     { key: "value" },
+ *     10000,
+ * );
  * if (response) {
  *     console.log("Success:", response);
  * }
  */
-declare function sendRequest<T>(url: string, payload: Record<string, unknown> | undefined): Promise<T | undefined>;
+declare function sendRequest<T>(url: string, payload: Record<string, unknown> | undefined, timeoutMs?: number): Promise<T | undefined>;
 
 type HandlerFunction = (...args: any[]) => void;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1106,11 +1106,11 @@ function removeByIdInPlace(array, idToRemove) {
 }
 
 // src/httpRequests.ts
-async function sendRequest(url, payload) {
+async function sendRequest(url, payload, timeoutMs = 5e3) {
   log(logLevels.debug, "Initiating request", ["network", "sendRequest"], { url, payload });
   const noPayload = !payload || Object.keys(payload).length === 0;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5e3);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     log(logLevels.debug, "Sending payload to URL", ["network", "sendRequest"], { url });
     let response;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1057,11 +1057,11 @@ function removeByIdInPlace(array, idToRemove) {
 }
 
 // src/httpRequests.ts
-async function sendRequest(url, payload) {
+async function sendRequest(url, payload, timeoutMs = 5e3) {
   log(logLevels.debug, "Initiating request", ["network", "sendRequest"], { url, payload });
   const noPayload = !payload || Object.keys(payload).length === 0;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5e3);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     log(logLevels.debug, "Sending payload to URL", ["network", "sendRequest"], { url });
     let response;

--- a/examples/httpRequestsEx/src/script.ts
+++ b/examples/httpRequestsEx/src/script.ts
@@ -21,7 +21,8 @@ form.addEventListener("submit", async (event) => {
         const payload = JSON.parse(payloadText); // Parse the payload
         responseDiv.textContent = "Sending request...";
 
-        const result = await sendRequest<any>(url, payload); // Call your function
+        const timeoutMs = 10000; // Allow slow endpoints more time
+        const result = await sendRequest<any>(url, payload, timeoutMs);
 
         if (result) {
             responseDiv.textContent = `Response:\n${JSON.stringify(result, null, 2)}`;

--- a/src/httpRequests.ts
+++ b/src/httpRequests.ts
@@ -6,18 +6,24 @@ import { log, logLevels } from "./logging";
  * @template T - The expected response type.
  * @param {string} url - The endpoint to which the request is sent.
  * @param {Record<string, unknown>} payload - The data to be sent in the request body.
+ * @param {number} [timeoutMs=5000] - Duration before the request is aborted, in milliseconds.
  * @returns {Promise<T | undefined>} A promise resolving to the response of the request, or `undefined` if an error occurs.
  * 
  * @example
  * // Example usage:
- * const response = await sendRequest<MyResponseType>("https://api.example.com/data", { key: "value" });
+ * const response = await sendRequest<MyResponseType>(
+ *     "https://api.example.com/data",
+ *     { key: "value" },
+ *     10000,
+ * );
  * if (response) {
  *     console.log("Success:", response);
  * }
  */
 export async function sendRequest<T>(
     url: string,
-    payload: Record<string, unknown> | undefined
+    payload: Record<string, unknown> | undefined,
+    timeoutMs = 5000,
 ): Promise<T | undefined> {
     // Log the initiation of the request
     log(logLevels.debug, "Initiating request", ["network", "sendRequest"], { url, payload });
@@ -25,7 +31,7 @@ export async function sendRequest<T>(
     const noPayload = !payload || Object.keys(payload).length === 0;
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000); // Timeout in 5s
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
         log(logLevels.debug, "Sending payload to URL", ["network", "sendRequest"], { url });


### PR DESCRIPTION
## Summary
- make sendRequest timeout configurable
- document configurable timeout and demonstrate in example

## Testing
- `npm run build`
- `npx eslint .` *(fails: ESLint couldn't find config)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b39ce501d483309866cffaa529f291