### PR TITLE
feat: add modular peer networking layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export * from './vector';
 export * from './math';
 export * from './screenResizer';
 export * from './fsm';
+export * from './peernet';

--- a/src/peerjs-shim.d.ts
+++ b/src/peerjs-shim.d.ts
@@ -1,1 +1,0 @@
-declare module 'peerjs';

--- a/src/peernet/codec/json.ts
+++ b/src/peernet/codec/json.ts
@@ -1,0 +1,18 @@
+import { Codec, Envelope } from '../types';
+
+export function createJsonCodec(): Codec {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  function encode<T>(env: Envelope<T>): Uint8Array {
+    const json = JSON.stringify(env);
+    return encoder.encode(json);
+  }
+
+  function decode(bytes: Uint8Array): Envelope {
+    const json = decoder.decode(bytes);
+    return JSON.parse(json) as Envelope;
+  }
+
+  return { encode, decode };
+}

--- a/src/peernet/index.ts
+++ b/src/peernet/index.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'crypto';
+import { createJsonCodec } from './codec/json';
+import { createPeerJsTransport } from './transport/peerjs';
+import { createSwimLite } from './membership/swimLite';
+import { createAdaptiveRouter } from './routing/adaptiveRouter';
+import { createTopics } from './pubsub/topics';
+import { createNoOpOwnership } from './ownership/noOp';
+import { createAllowAllSecurity } from './security/allowAll';
+import type {
+  Envelope,
+  PeerId,
+  PeerNetOptions,
+  QoS,
+  Router,
+} from './types';
+
+export async function init(opts: PeerNetOptions = {}) {
+  const codec = opts.codec || createJsonCodec();
+  const transport = opts.transport || createPeerJsTransport();
+  await transport.start();
+  const membership = opts.membership || createSwimLite(transport);
+  membership.start();
+  const router: Router =
+    opts.router || createAdaptiveRouter(transport, membership, codec);
+  router.start();
+  const pubsub = opts.pubsub || createTopics(router);
+  const ownership =
+    opts.ownership || createNoOpOwnership();
+  const security = opts.security || createAllowAllSecurity();
+
+  const msgHandlers = new Map<PeerId, (msg: unknown, meta: Envelope) => void>();
+
+  router.onReceive((env) => {
+    if (!security.authorize(env)) return;
+    if (env.dst === membership.self()) {
+      const handler = msgHandlers.get(env.src);
+      handler?.(env.payload, env);
+    }
+  });
+
+  function id() {
+    return membership.self();
+  }
+
+  function onPeerJoin(h: (p: PeerId) => void) {
+    membership.onJoin(h);
+  }
+
+  function onPeerLeave(h: (p: PeerId) => void) {
+    membership.onLeave((p) => h(p));
+  }
+
+  function onMessageFrom(peer: PeerId, h: (msg: unknown, meta: Envelope) => void) {
+    msgHandlers.set(peer, h);
+  }
+
+  function sendToPeer(peer: PeerId, payload: unknown, qos: QoS = 'ff') {
+    const env: Envelope = {
+      id: randomUUID(),
+      v: 1,
+      src: membership.self(),
+      dst: peer,
+      type: 'msg',
+      qos,
+      ttl: 5,
+      hop: 0,
+      ts: Date.now(),
+      payload,
+    };
+    router.send(env).catch(() => {});
+  }
+
+  function routeToPeer(peer: PeerId, payload: unknown, qos: QoS = 'ff') {
+    sendToPeer(peer, payload, qos);
+  }
+
+  function subscribe(topic: string, handler: (msg: unknown, meta: Envelope) => void) {
+    return pubsub.subscribe(topic, handler);
+  }
+
+  function publish(topic: string, msg: unknown, opts?: { qos?: QoS }) {
+    pubsub.publish(topic, msg, opts);
+  }
+
+  async function claim(entity: string) {
+    return ownership.claim(entity);
+  }
+
+  async function release(entity: string) {
+    return ownership.release(entity);
+  }
+
+  function onOwnershipChange(entity: string, h: (owner: PeerId | null) => void) {
+    return ownership.onChange(entity, h);
+  }
+
+  function join(topic: string) {
+    pubsub.join(topic);
+  }
+
+  function leave(topic: string) {
+    pubsub.leave(topic);
+  }
+
+  async function shutdown() {
+    router.stop();
+    membership.stop();
+    await transport.stop();
+  }
+
+  return {
+    id: id(),
+    onPeerJoin,
+    onPeerLeave,
+    onMessageFrom,
+    sendToPeer,
+    routeToPeer,
+    subscribe,
+    publish,
+    claim,
+    release,
+    onOwnershipChange,
+    join,
+    leave,
+    shutdown,
+  };
+}
+
+export * from './types';
+export { createPeerJsTransport } from './transport/peerjs';
+export { createSwimLite } from './membership/swimLite';
+export { createAdaptiveRouter } from './routing/adaptiveRouter';
+export { createTopics } from './pubsub/topics';
+export { createNoOpOwnership } from './ownership/noOp';
+export { createClaimFirst } from './ownership/claimFirst';
+export { createJsonCodec } from './codec/json';
+export { createAllowAllSecurity } from './security/allowAll';

--- a/src/peernet/membership/swimLite.ts
+++ b/src/peernet/membership/swimLite.ts
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'events';
+import type { Membership, PeerId, Transport } from '../types';
+
+export function createSwimLite(transport: Transport, intervalMs = 1000): Membership {
+  const emitter = new EventEmitter();
+  let timer: NodeJS.Timeout | null = null;
+  let known = new Set<PeerId>();
+
+  function start() {
+    timer = setInterval(poll, intervalMs);
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function self(): PeerId {
+    return transport.localId();
+  }
+
+  function peers() {
+    return new Set(known);
+  }
+
+  function onJoin(h: (p: PeerId) => void) {
+    emitter.on('join', h);
+  }
+
+  function onLeave(h: (p: PeerId, reason: 'timeout' | 'graceful') => void) {
+    emitter.on('leave', h);
+  }
+
+  function onPeersChanged(h: () => void) {
+    emitter.on('changed', h);
+  }
+
+  function poll() {
+    const current = transport.neighbors();
+    for (const p of current) {
+      if (!known.has(p)) {
+        known.add(p);
+        emitter.emit('join', p);
+        emitter.emit('changed');
+      }
+    }
+    for (const p of [...known]) {
+      if (!current.has(p)) {
+        known.delete(p);
+        emitter.emit('leave', p, 'timeout');
+        emitter.emit('changed');
+      }
+    }
+  }
+
+  return { start, stop, self, peers, onJoin, onLeave, onPeersChanged };
+}

--- a/src/peernet/ownership/claimFirst.ts
+++ b/src/peernet/ownership/claimFirst.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'events';
+import type { EntityId, Membership, Ownership, PeerId } from '../types';
+
+export function createClaimFirst(membership: Membership): Ownership {
+  const owners = new Map<EntityId, PeerId>();
+  const emitter = new EventEmitter();
+
+  async function claim(entity: EntityId): Promise<'granted' | 'contended' | 'denied'> {
+    const selfId = membership.self();
+    const current = owners.get(entity);
+    if (!current) {
+      owners.set(entity, selfId);
+      emitter.emit(entity, selfId);
+      return 'granted';
+    }
+    if (current === selfId) return 'granted';
+    if (selfId < current) {
+      owners.set(entity, selfId);
+      emitter.emit(entity, selfId);
+      return 'contended';
+    }
+    return 'denied';
+  }
+
+  async function release(entity: EntityId) {
+    const selfId = membership.self();
+    const current = owners.get(entity);
+    if (current === selfId) {
+      owners.delete(entity);
+      emitter.emit(entity, null);
+    }
+  }
+
+  function ownerOf(entity: EntityId): PeerId | null {
+    return owners.get(entity) ?? null;
+  }
+
+  function onChange(entity: EntityId, h: (owner: PeerId | null) => void) {
+    emitter.on(entity, h);
+    return () => emitter.off(entity, h);
+  }
+
+  return { claim, release, ownerOf, onChange };
+}

--- a/src/peernet/ownership/noOp.ts
+++ b/src/peernet/ownership/noOp.ts
@@ -1,0 +1,21 @@
+import type { EntityId, Ownership, PeerId } from '../types';
+
+export function createNoOpOwnership(): Ownership {
+  async function claim(): Promise<'granted'> {
+    return 'granted';
+  }
+
+  async function release() {
+    /* no-op */
+  }
+
+  function ownerOf(): PeerId | null {
+    return null;
+  }
+
+  function onChange(_entity: EntityId, _h: (owner: PeerId | null) => void) {
+    return () => {};
+  }
+
+  return { claim, release, ownerOf, onChange };
+}

--- a/src/peernet/pubsub/topics.ts
+++ b/src/peernet/pubsub/topics.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'crypto';
+import type { Envelope, PubSub, QoS, Router, Topic } from '../types';
+
+export function createTopics(router: Router): PubSub {
+  const subs = new Map<Topic, Set<(msg: unknown, meta: Envelope) => void>>();
+
+  router.onReceive((env) => {
+    if (!env.topic) return;
+    const handlers = subs.get(env.topic);
+    if (!handlers) return;
+    handlers.forEach((h) => h(env.payload, env));
+  });
+
+  function publish<T>(topic: Topic, msg: T, opts?: { qos?: QoS }) {
+    const env: Envelope<T> = {
+      id: randomUUID(),
+      v: 1,
+      src: '',
+      topic,
+      type: 'pub',
+      qos: opts?.qos || 'ff',
+      ttl: 3,
+      hop: 0,
+      ts: Date.now(),
+      payload: msg,
+    };
+    router.send(env).catch(() => {});
+  }
+
+  function subscribe<T>(topic: Topic, handler: (msg: T, meta: Envelope<T>) => void) {
+    const set = subs.get(topic) || new Set();
+    set.add(handler as (msg: unknown, meta: Envelope) => void);
+    subs.set(topic, set);
+    return () => {
+      set.delete(handler as (msg: unknown, meta: Envelope) => void);
+    };
+  }
+
+  function join(_topic: Topic) {
+    /* presence only */
+  }
+
+  function leave(_topic: Topic) {
+    /* presence only */
+  }
+
+  return { publish, subscribe, join, leave };
+}

--- a/src/peernet/routing/adaptiveRouter.ts
+++ b/src/peernet/routing/adaptiveRouter.ts
@@ -1,0 +1,53 @@
+import type { Codec, Envelope, Membership, PeerId, Router, Transport } from '../types';
+
+export function createAdaptiveRouter(
+  transport: Transport,
+  membership: Membership,
+  codec: Codec
+): Router {
+  const seen = new Map<string, number>();
+  const receivers = new Set<(env: Envelope) => void>();
+
+  function start() {
+    transport.onData(handleData);
+  }
+
+  function stop() {
+    transport.onData(() => {});
+    seen.clear();
+  }
+
+  async function send<T>(env: Envelope<T>) {
+    const bytes = codec.encode(env);
+    if (env.dst && transport.neighbors().has(env.dst)) {
+      await transport.connectTo(env.dst);
+      await transport.send(env.dst, bytes);
+      return;
+    }
+    for (const n of membership.peers()) {
+      if (n !== env.src) {
+        transport.send(n, bytes);
+      }
+    }
+  }
+
+  function onReceive<T>(h: (env: Envelope<T>) => void) {
+    receivers.add(h as (env: Envelope) => void);
+  }
+
+  function handleData(peer: PeerId, bytes: Uint8Array) {
+    const env = codec.decode(bytes);
+    if (seen.has(env.id)) return;
+    seen.set(env.id, Date.now());
+    if (env.dst && env.dst !== membership.self()) {
+      if (env.hop < env.ttl) {
+        env.hop += 1;
+        send(env).catch(() => {});
+      }
+      return;
+    }
+    for (const h of receivers) h(env);
+  }
+
+  return { start, stop, send, onReceive };
+}

--- a/src/peernet/security/allowAll.ts
+++ b/src/peernet/security/allowAll.ts
@@ -1,0 +1,8 @@
+import type { Envelope, Security } from '../types';
+
+export function createAllowAllSecurity(): Security {
+  function authorize(_env: Envelope): boolean {
+    return true;
+  }
+  return { authorize };
+}

--- a/src/peernet/transport/peerjs.ts
+++ b/src/peernet/transport/peerjs.ts
@@ -1,0 +1,74 @@
+import Peer, { DataConnection, PeerJSOption } from 'peerjs';
+import type { PeerId, Transport } from '../types';
+
+export type PeerJsOptions = PeerJSOption;
+
+export function createPeerJsTransport(opts?: PeerJsOptions): Transport {
+  const connections = new Map<PeerId, DataConnection>();
+  let peer: Peer | null = null;
+  let dataHandler: ((peer: PeerId, bytes: Uint8Array) => void) | null = null;
+
+  async function start() {
+    peer = opts ? new Peer(opts) : new Peer();
+    peer.on('connection', handleConnection);
+    await new Promise<void>((resolve, reject) => {
+      peer?.once('open', () => resolve());
+      peer?.once('error', (err: unknown) => reject(err));
+    });
+  }
+
+  async function stop() {
+    connections.forEach((c) => c.close());
+    connections.clear();
+    peer?.removeAllListeners();
+    peer?.destroy();
+    peer = null;
+  }
+
+  function localId(): PeerId {
+    return peer?.id || '';
+  }
+
+  async function connectTo(target: PeerId) {
+    if (!peer) throw new Error('transport not started');
+    if (connections.has(target)) return;
+    const conn = peer.connect(target);
+    conn.on('open', () => {
+      connections.set(target, conn);
+      conn.on('data', (data: unknown) => {
+        if (data instanceof ArrayBuffer) {
+          dataHandler?.(target, new Uint8Array(data));
+        }
+      });
+      conn.on('close', () => connections.delete(target));
+    });
+  }
+
+  async function send(target: PeerId, bytes: Uint8Array) {
+    const conn = connections.get(target);
+    conn?.send(bytes);
+  }
+
+  function onData(handler: (peer: PeerId, bytes: Uint8Array) => void) {
+    dataHandler = handler;
+  }
+
+  function neighbors() {
+    return new Set(connections.keys());
+  }
+
+  function handleConnection(conn: DataConnection) {
+    const id = conn.peer;
+    connections.set(id, conn);
+    conn.on('data', (data: unknown) => {
+      if (data instanceof ArrayBuffer) {
+        dataHandler?.(id, new Uint8Array(data));
+      }
+    });
+    conn.on('close', () => {
+      connections.delete(id);
+    });
+  }
+
+  return { start, stop, localId, connectTo, send, onData, neighbors };
+}

--- a/src/peernet/types.ts
+++ b/src/peernet/types.ts
@@ -1,0 +1,86 @@
+export type PeerId = string;
+export type Topic = string;
+export type EntityId = string;
+
+export type QoS = 'ff' | 'alo';
+export type Addr = { peer?: PeerId; topic?: Topic };
+
+export type Envelope<T = unknown> = {
+  id: string;
+  v: 1;
+  src: PeerId;
+  dst?: PeerId;
+  topic?: Topic;
+  entity?: EntityId;
+  owner?: PeerId | null;
+  type: string;
+  qos: QoS;
+  ttl: number;
+  hop: number;
+  ts: number;
+  payload: T;
+  trace?: PeerId[];
+  sig?: string;
+};
+
+export interface Transport {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  localId(): PeerId;
+  connectTo(peer: PeerId): Promise<void>;
+  send(peer: PeerId, bytes: Uint8Array): Promise<void>;
+  onData(handler: (peer: PeerId, bytes: Uint8Array) => void): void;
+  neighbors(): Set<PeerId>;
+}
+
+export interface Membership {
+  start(): void;
+  stop(): void;
+  self(): PeerId;
+  peers(): Set<PeerId>;
+  onJoin(h: (p: PeerId) => void): void;
+  onLeave(h: (p: PeerId, reason: 'timeout' | 'graceful') => void): void;
+  onPeersChanged(h: () => void): void;
+}
+
+export interface Router {
+  start(): void;
+  stop(): void;
+  send<T>(env: Envelope<T>): Promise<void>;
+  onReceive<T>(h: (env: Envelope<T>) => void): void;
+}
+
+export interface PubSub {
+  publish<T>(topic: Topic, msg: T, opts?: { qos?: QoS }): void;
+  subscribe<T>(topic: Topic, handler: (msg: T, meta: Envelope<T>) => void): () => void;
+  join(topic: Topic): void;
+  leave(topic: Topic): void;
+}
+
+export interface Ownership {
+  claim(entity: EntityId, opts?: { ttlMs?: number }): Promise<'granted' | 'contended' | 'denied'>;
+  release(entity: EntityId): Promise<void>;
+  ownerOf(entity: EntityId): PeerId | null;
+  onChange(entity: EntityId, h: (owner: PeerId | null) => void): () => void;
+}
+
+export interface Codec {
+  encode<T>(env: Envelope<T>): Uint8Array;
+  decode(bytes: Uint8Array): Envelope;
+}
+
+export interface Security {
+  authorize(env: Envelope): boolean;
+}
+
+export type PeerNetOptions = {
+  transport?: Transport;
+  membership?: Membership;
+  router?: Router;
+  pubsub?: PubSub;
+  ownership?: Ownership;
+  codec?: Codec;
+  security?: Security;
+  qosDefaults?: { direct?: QoS; topic?: QoS };
+  limits?: { maxTtl?: number; maxMsgBytes?: number; inflight?: number };
+};


### PR DESCRIPTION
## Summary
- add decoupled PeerNet modules (transport, membership, routing, pubsub, ownership)
- expose new PeerNet facade and supporting factories
- wire new PeerNet exports in library entry point
- use PeerJS-based transport for peer connections

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4f061eaa083308a7eecaa09c6fb37